### PR TITLE
:bug:update fail when a column value is 0

### DIFF
--- a/src/Model.ts
+++ b/src/Model.ts
@@ -307,7 +307,7 @@ class Model {
 		const deleteAllArray = []
 
 		for (const col of this.schema.columns) {
-			if (!col.primaryKey && values[col.name]) {
+			if (!col.primaryKey && values[col.name] !== undefined) {
 				let item: any = {}
 				let value: any = values[col.name]
 


### PR DESCRIPTION
I think here should check whether the value is undefined instead of simply convert it to boolean.
Because when update a column value to 0 like this:
`Foo.update({ id: 'xx' }, { count: 0 });`
It throws an exception, but that operation should be valid.